### PR TITLE
Dynamically add error to options.errorMessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,3 +107,9 @@ Features:
 
 - added escapeValue method to field.js, catches single and double quotes before
 writing back to template.
+
+0.2.2 (10.09.14)
+================
+
+- Show error messge by setting new Form.error in setValues callback.
+- Allow api errors to be propogated thru to form error handler, even if formHandler.valid is true

--- a/lib/form.js
+++ b/lib/form.js
@@ -204,16 +204,16 @@ var Form = Class.extend({
             return next(err);
         }
         if (req.forms[this.formName].valid) {
-            options.renderSuccess = true;
-            this.options.setValues(req, res, this.dispatchPostResponse.bind(this, req, res, next));
+            this.options.setValues(req, res, this.dispatchPostResponse.bind(this, req, res, next, options));
         } else {
-            options.renderErrors = true;
-            this.dispatchPostResponse(req, res, next, req.forms[this.formName].validationErrors);
+            this.dispatchPostResponse(req, res, next, options, req.forms[this.formName].validationErrors);
         }
     },
 
-    dispatchPostResponse: function dispatchPostResponse(req, res, next, err) {
+    dispatchPostResponse: function dispatchPostResponse(req, res, next, options, err) {
         if (err) {
+            options.renderErrors = true;
+            options.errorMessage = err;
             this.options.errorHandler(err, req, res, next);
         } else {
             this.options.successHandler(req, res, next);

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "express",
     "fields"
   ],
-  "version": "0.2.1",
+  "version": "0.2.2",
   "engines": {
     "node": ">= 0.10.0"
   },


### PR DESCRIPTION
- can show error messge by setting new Form.error in setValues callback.
- will allow api errors to be propogated thru to form error handler
- bump version 0.2.2
- changelog update

![](http://cdn3.whatculture.com/wp-content/uploads/2014/04/jeanluchappy.gif)
