### PR TITLE
Remove getForm and replace with getFormObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,3 +123,9 @@ writing back to template.
 ================
 
 - put req.forms[this.formName] in method on form so can be overwritten. Useful for returning different values when error handling
+
+0.2.4 (15.09.14)
+================
+
+- getForm removed
+- getFormObject, accepts error and request, conditional logic can be applied

--- a/lib/form.js
+++ b/lib/form.js
@@ -182,7 +182,7 @@ var Form = Class.extend({
         }
 
         req.forms[this.formName] = new FormHandler(this, values, options);
-        this._fields = this.getForm(req).fields;
+        this._fields = req.forms[this.formName].fields;
 
         callback(req, res, err, options);
     },
@@ -203,10 +203,10 @@ var Form = Class.extend({
         if (err) {
             return next(err);
         }
-        if (this.getForm(req).valid) {
+        if (req.forms[this.formName].valid) {
             this.options.setValues(req, res, this.dispatchPostResponse.bind(this, req, res, next, options));
         } else {
-            this.dispatchPostResponse(req, res, next, options, this.getForm(req).validationErrors);
+            this.dispatchPostResponse(req, res, next, options, req.forms[this.formName].validationErrors);
         }
     },
 
@@ -242,7 +242,7 @@ var Form = Class.extend({
                 if (this.options.redirectUrl) {
                     res.status(200).json({ redirect: this.options.redirectUrl });
                 } else {
-                    formObject.values = Object.keys(formValues).length ? formValues : this.getForm(req).values;
+                    formObject.values = Object.keys(formValues).length ? formValues : req.forms[this.formName].values;
                     res.status(200).json(formObject);
                 }
             }.bind(this));
@@ -258,7 +258,7 @@ var Form = Class.extend({
 
     htmlErrors: function htmlErrors(err, req) {
         if (this.options.htmlErrors || req.headers['x-errors-as-html'] === 'enabled') {
-            var form = this.getForm(req);
+            var form = req.forms[this.formName];
             err.message = form.errorHtml;
             _.each(form.fields, function (field) {
                 if (err.fields[field.id]) {
@@ -269,8 +269,11 @@ var Form = Class.extend({
         return err;
     },
 
-    getForm: function getForm(req) {
-        return req.forms[this.formName];
+    getFormObject: function getFormObject(req, err) {
+        return {
+            values: req.forms[this.formName].values,
+            errorMessage: err
+        };
     },
 
     errorHandler: function errorHandler(err, req, res, next) {
@@ -278,10 +281,7 @@ var Form = Class.extend({
             return next(err);
         }
 
-        var formObject = {
-            values: this.getForm(req).values,
-            errorMessage: err
-        };
+        var formObject = this.getFormObject(req, err);
 
         if (req.xhr) {
             formObject.errorMessage = this.htmlErrors(err, req);


### PR DESCRIPTION
- getFormObject allows for error inspection and conditional logic
- getform called from error/success handler not apprpriate

![](https://encrypted-tbn1.gstatic.com/images?q=tbn:ANd9GcSFZWGeGK0vLqTGDAAXrkXhungicYnkn8jcgCLiFL-koPDRpG_5CA)
